### PR TITLE
feat: Create AMI for Docker Swarm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,20 @@ erl_crash.dump
 
 /priv/plts/*.plt
 /priv/plts/*.plt.hash
+
+# Cache objects
+packer_cache/
+
+# Crash log
+crash.log
+
+# https://www.packer.io/guides/hcl/variables
+# Exclude all .pkrvars.hcl files, which are likely to contain sensitive data,
+# such as password, private keys, and other secrets. These should not be part of
+# version control as they are data points which are potentially sensitive and
+# subject to change depending on the environment.
+#
+*.pkrvars.hcl
+
+# For built boxes
+*.box

--- a/enviroments/production/.terraform.lock.hcl
+++ b/enviroments/production/.terraform.lock.hcl
@@ -1,0 +1,65 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.13.1"
+  constraints = "5.13.1"
+  hashes = [
+    "h1:T/p3Gp8uAvRk3BmBZI/B7JIUpxF+2DygvBsv2UvJK4w=",
+    "zh:0d107e410ecfbd5d2fb5ff9793f88e2ce03ae5b3bda4e3b772b5d146cdd859d8",
+    "zh:1080cf6a402939ec4ad393380f2ab2dfdc0e175903e08ed796aa22eb95868847",
+    "zh:300420d642c3ada48cfe633444eafa7bcd410cd6a8503de2384f14ac54dc3ce3",
+    "zh:4e0121014a8d6ef0b1ab4634877545737bb54e951340f1b67ffea8cd22b2d252",
+    "zh:59b401bbf95dc8c6bea58085ff286543380f176271251193eac09cb7fcf619b7",
+    "zh:5dfaf51e979131710ce8e1572e6012564e68c7c842e3d9caaaeb0fe6af15c351",
+    "zh:84bb75dafca056d7c3783be5185187fdd3294f902e9d72f7655f2efb5e066650",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:aa4e2b9f699d497041679bc05ca34ac21a5184298eb1813f35455b1883977910",
+    "zh:b51a4f08d84b071128df68a95cfa5114301a50bf8ab8e655dcf7e384e5bc6458",
+    "zh:bce284ac6ebb65053d9b703048e3157bf4175782ea9dbaec9f64dc2b6fcefb0c",
+    "zh:c748f78b79b354794098b06b18a02aefdb49be144dff8876c9204083980f7de0",
+    "zh:ee69d9aef5ca532392cdc26499096f3fa6e55f8622387f78194ebfaadb796aef",
+    "zh:ef561bee58e4976474bc056649095737fa3b2bcb74602032415d770bfc620c1f",
+    "zh:f696d8416c57c31f144d432779ba34764560a95937db3bb3dd2892a791a6d5a7",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.4.0"
+  constraints = "2.4.0"
+  hashes = [
+    "h1:ZUEYUmm2t4vxwzxy1BvN1wL6SDWrDxfH7pxtzX8c6d0=",
+    "zh:53604cd29cb92538668fe09565c739358dc53ca56f9f11312b9d7de81e48fab9",
+    "zh:66a46e9c508716a1c98efbf793092f03d50049fa4a83cd6b2251e9a06aca2acf",
+    "zh:70a6f6a852dd83768d0778ce9817d81d4b3f073fab8fa570bff92dcb0824f732",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:82a803f2f484c8b766e2e9c32343e9c89b91997b9f8d2697f9f3837f62926b35",
+    "zh:9708a4e40d6cc4b8afd1352e5186e6e1502f6ae599867c120967aebe9d90ed04",
+    "zh:973f65ce0d67c585f4ec250c1e634c9b22d9c4288b484ee2a871d7fa1e317406",
+    "zh:c8fa0f98f9316e4cfef082aa9b785ba16e36ff754d6aba8b456dab9500e671c6",
+    "zh:cfa5342a5f5188b20db246c73ac823918c189468e1382cb3c48a9c0c08fc5bf7",
+    "zh:e0e2b477c7e899c63b06b38cd8684a893d834d6d0b5e9b033cedc06dd7ffe9e2",
+    "zh:f62d7d05ea1ee566f732505200ab38d94315a4add27947a60afa29860822d3fc",
+    "zh:fa7ce69dde358e172bd719014ad637634bbdabc49363104f4fca759b4b73f2ce",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.0.4"
+  constraints = "4.0.4"
+  hashes = [
+    "h1:GZcFizg5ZT2VrpwvxGBHQ/hO9r6g0vYdQqx3bFD3anY=",
+    "zh:23671ed83e1fcf79745534841e10291bbf34046b27d6e68a5d0aab77206f4a55",
+    "zh:45292421211ffd9e8e3eb3655677700e3c5047f71d8f7650d2ce30242335f848",
+    "zh:59fedb519f4433c0fdb1d58b27c210b27415fddd0cd73c5312530b4309c088be",
+    "zh:5a8eec2409a9ff7cd0758a9d818c74bcba92a240e6c5e54b99df68fff312bbd5",
+    "zh:5e6a4b39f3171f53292ab88058a59e64825f2b842760a4869e64dc1dc093d1fe",
+    "zh:810547d0bf9311d21c81cc306126d3547e7bd3f194fc295836acf164b9f8424e",
+    "zh:824a5f3617624243bed0259d7dd37d76017097dc3193dac669be342b90b2ab48",
+    "zh:9361ccc7048be5dcbc2fafe2d8216939765b3160bd52734f7a9fd917a39ecbd8",
+    "zh:aa02ea625aaf672e649296bce7580f62d724268189fe9ad7c1b36bb0fa12fa60",
+    "zh:c71b4cd40d6ec7815dfeefd57d88bc592c0c42f5e5858dcc88245d371b4b8b1e",
+    "zh:dabcd52f36b43d250a3d71ad7abfa07b5622c69068d989e60b79b2bb4f220316",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/enviroments/production/main.tf
+++ b/enviroments/production/main.tf
@@ -1,0 +1,8 @@
+module "swarm" {
+  source           = "../../modules/cloud/aws/compute/swarm"
+  private_key_path = "${path.module}/private_key.pem"
+}
+
+output "swarm_ssh_command" {
+  value = module.swarm.ssh_command
+}

--- a/modules/cloud/aws/compute/swarm/main.tf
+++ b/modules/cloud/aws/compute/swarm/main.tf
@@ -1,0 +1,120 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.13.1"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "4.0.4"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "2.4.0"
+    }
+  }
+}
+
+data "aws_vpc" "main" {
+  filter {
+    name   = "isDefault"
+    values = ["true"]
+  }
+}
+
+data "aws_subnets" "main_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.main.id]
+  }
+}
+
+data "aws_ami" "amazon_linux_docker" {
+  most_recent = true
+  filter {
+    name   = "name"
+    values = ["amazon-linux-docker*"]
+  }
+  owners = ["867973538688"]
+}
+
+resource "tls_private_key" "rsa" {
+  algorithm = "RSA"
+  rsa_bits  = "4096"
+}
+
+resource "local_sensitive_file" "private_key" {
+  filename        = var.private_key_path
+  content         = tls_private_key.rsa.private_key_pem
+  file_permission = "0400"
+}
+
+resource "aws_key_pair" "deployer_key" {
+  key_name   = "swarm-key"
+  public_key = tls_private_key.rsa.public_key_openssh
+}
+
+
+resource "aws_instance" "my_swarm" {
+  ami               = data.aws_ami.amazon_linux_docker.id
+  availability_zone = "ap-southeast-2a"
+  instance_type     = "t2.micro"
+  key_name          = aws_key_pair.deployer_key.key_name
+  subnet_id         = data.aws_subnets.main_subnets.ids[1]
+
+  tags = {
+    "Name" = "docker-swarm-manager"
+  }
+
+  vpc_security_group_ids = [
+    aws_security_group.swarm_sg.id
+  ]
+}
+
+resource "aws_security_group" "swarm_sg" {
+  egress = [
+    {
+      cidr_blocks = [
+        "0.0.0.0/0",
+      ]
+      description      = ""
+      from_port        = 0
+      ipv6_cidr_blocks = []
+      prefix_list_ids  = []
+      protocol         = "-1"
+      security_groups  = []
+      self             = false
+      to_port          = 0
+    },
+  ]
+  ingress = [
+    {
+      cidr_blocks = [
+        "0.0.0.0/0",
+      ]
+      description      = ""
+      from_port        = 22
+      ipv6_cidr_blocks = []
+      prefix_list_ids  = []
+      protocol         = "tcp"
+      security_groups  = []
+      self             = false
+      to_port          = 22
+    },
+    {
+      cidr_blocks = [
+        "0.0.0.0/0",
+      ]
+      description      = ""
+      from_port        = 4000
+      ipv6_cidr_blocks = []
+      prefix_list_ids  = []
+      protocol         = "tcp"
+      security_groups  = []
+      self             = false
+      to_port          = 4000
+    },
+  ]
+  name   = "swarm_pool_ports"
+  vpc_id = data.aws_vpc.main.id
+}

--- a/modules/cloud/aws/compute/swarm/outputs.tf
+++ b/modules/cloud/aws/compute/swarm/outputs.tf
@@ -1,0 +1,4 @@
+output "ssh_command" {
+  value       = "ssh -i ${var.private_key_path} ec2-user@${aws_instance.my_swarm.public_ip}"
+  description = "The SSH command to connect to the instance."
+}

--- a/modules/cloud/aws/compute/swarm/variables.tf
+++ b/modules/cloud/aws/compute/swarm/variables.tf
@@ -1,0 +1,4 @@
+variable "private_key_path" {
+  description = "The path to the private key file."
+  type        = string
+}

--- a/packer/aws-docker.pkr.hcl
+++ b/packer/aws-docker.pkr.hcl
@@ -1,0 +1,34 @@
+packer {
+  required_plugins {
+    amazon = {
+      version = ">= 0.0.2"
+      source = "github.com/hashicorp/amazon"
+    }
+  }
+}
+
+source "amazon-ebs" "base" {
+  ami_regions = var.ami_regions
+  source_ami_filter {
+    filters = {
+      name = "al2023-ami-2023*"
+      architecture = "x86_64"
+    }
+    most_recent = true
+    owners = ["amazon"]
+  }
+
+  instance_type = "t2.micro"
+  ssh_username = "ec2-user"
+  ami_name = "amazon-linux-docker_{{timestamp}}"
+}
+
+build {
+  sources = ["source.amazon-ebs.base"]
+
+  provisioner "shell" {
+    script = "setup.sh"
+
+    execute_command = "cloud-init status --wait && sudo -E sh '{{ .Path }}'"
+  }
+}

--- a/packer/setup.sh
+++ b/packer/setup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# in packer/setup.sh
+
+set -ex
+
+sudo dnf update -y
+sudo dnf install -y docker nc
+sudo systemctl start docker
+sudo systemctl enable docker
+sudo usermod -a -G docker ec2-user
+sudo dnf install -y nmap

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -1,0 +1,4 @@
+variable "ami_regions" {
+  type = list(string)
+  description = "A list of regions where the AMI will be copied to."
+}


### PR DESCRIPTION
This change is being made to create an Amazon Machine Image (AMI)
that is pre-configured for use with Docker Swarm. This will allow
for easier deployment and scaling of Docker containers in a
production environment.

closes #16
