### PR TITLE
feat: Add Docker Swarm initial setup for AWS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,7 @@ crash.log
 
 # For built boxes
 *.box
+
+*.pem
+
+.DS_Store

--- a/modules/cloud/aws/compute/swarm/main.tf
+++ b/modules/cloud/aws/compute/swarm/main.tf
@@ -66,6 +66,11 @@ resource "aws_instance" "my_swarm" {
     "Name" = "docker-swarm-manager"
   }
 
+  user_data = <<-EOF
+    #!/usr/bin/env bash
+    docker swarm init
+  EOF
+
   vpc_security_group_ids = [
     aws_security_group.swarm_sg.id
   ]


### PR DESCRIPTION
This change adds the initial setup for Docker Swarm on AWS,
allowing for the orchestration of containerized applications
across multiple EC2 instances.

closes #9
